### PR TITLE
Operation queue parameter

### DIFF
--- a/Source/Promise.swift
+++ b/Source/Promise.swift
@@ -10,8 +10,14 @@ public class Promise<T> {
         self.value = value
     }
     
-    public init(_ executor: (resolve: Promise<T> -> ()) -> ()) {
-        executor(resolve: resolve)
+    public init(_ queue: dispatch_queue_t? = nil, executor: (resolve: Promise<T> -> ()) -> ()) {
+        if let queue = queue {
+            dispatch_async(queue) {
+                executor(resolve: self.resolve)
+            }
+        } else {
+            executor(resolve: resolve)
+        }
     }
     
     private func resolve(promise: Promise<T>) {

--- a/Tests/PromiseKTests.swift
+++ b/Tests/PromiseKTests.swift
@@ -157,6 +157,21 @@ class PromiseKTests: XCTestCase {
         
         waitForExpectationsWithTimeout(3.0, handler: nil)
     }
+    
+    func testOperationQueue() {
+        let expectation = expectationWithDescription("")
+        let queue = dispatch_queue_create("test", nil)
+        
+        pure(1).flatMap { i -> Promise<Int> in
+            return Promise<Int>(queue) { resolve in
+                XCTAssert(!NSThread.isMainThread())
+                expectation.fulfill()
+                resolve(pure(i + 1))
+            }
+        }
+        
+        waitForExpectationsWithTimeout(3.0, handler: nil)
+    }
 }
 
 func asyncGet(value: Int) -> Promise<Int> {


### PR DESCRIPTION
I hope to select operation queue in executor block like next, 

``` swift
Promise<Int>(queue) { resolve in
  // this block run on "queue".
}
```
